### PR TITLE
Remove maven to allow usage with newer react-native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,6 @@ def safeExtGet(prop, fallback) {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
@@ -39,7 +38,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
@@ -56,16 +54,6 @@ android {
 }
 
 repositories {
-    // ref: https://www.baeldung.com/maven-local-repository
-    mavenLocal()
-    maven {
-        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-        url "$rootDir/../node_modules/react-native/android"
-    }
-    maven {
-        // Android JSC is installed from npm
-        url "$rootDir/../node_modules/jsc-android/dist"
-    }
     google()
     jcenter()
 }
@@ -111,7 +99,6 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
         include '**/*.java'
     }
 
@@ -142,10 +129,5 @@ afterEvaluate { project ->
 
     task installArchives(type: Upload) {
         configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
-            configureReactNativePom pom
-        }
     }
 }

--- a/android/src/main/java/com/akvelon/reactnativesmsuserconsent/ReactNativeSmsUserConsentModule.java
+++ b/android/src/main/java/com/akvelon/reactnativesmsuserconsent/ReactNativeSmsUserConsentModule.java
@@ -36,8 +36,8 @@ public class ReactNativeSmsUserConsentModule extends ReactContextBaseJavaModule 
         Activity activity = getCurrentActivity();
         if (activity == null) {
             throw new RNSmsUserConsentException(
-                Errors.NULL_ACTIVITY,
-                "Could not subscribe, activity is null"
+                    Errors.NULL_ACTIVITY,
+                    "Could not subscribe, activity is null"
             );
         }
 
@@ -45,10 +45,10 @@ public class ReactNativeSmsUserConsentModule extends ReactContextBaseJavaModule 
 
         broadcastReceiver = new SmsBroadcastReceiver(getCurrentActivity(), this);
         getCurrentActivity().registerReceiver(
-            broadcastReceiver,
-            new IntentFilter(SmsRetriever.SMS_RETRIEVED_ACTION),
-            SmsRetriever.SEND_PERMISSION,
-            null
+                broadcastReceiver,
+                new IntentFilter(SmsRetriever.SMS_RETRIEVED_ACTION),
+                SmsRetriever.SEND_PERMISSION,
+                null
         );
 
         reactContext.addActivityEventListener(listener);
@@ -59,15 +59,15 @@ public class ReactNativeSmsUserConsentModule extends ReactContextBaseJavaModule 
 
         if (activity == null) {
             throw new RNSmsUserConsentException(
-                Errors.NULL_ACTIVITY,
-                "Could not unsubscribe, activity is null"
+                    Errors.NULL_ACTIVITY,
+                    "Could not unsubscribe, activity is null"
             );
         }
 
         if (broadcastReceiver == null) {
             throw new RNSmsUserConsentException(
-                Errors.NULL_BROADCAST_RECEIVER,
-                "Could not unsubscribe, broadcastReceiver is null"
+                    Errors.NULL_BROADCAST_RECEIVER,
+                    "Could not unsubscribe, broadcastReceiver is null"
             );
         }
 
@@ -106,16 +106,24 @@ public class ReactNativeSmsUserConsentModule extends ReactContextBaseJavaModule 
         WritableMap params = Arguments.createMap();
         params.putString("sms", sms);
         reactContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit(AKV_SMS_RETRIEVED, params);
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(AKV_SMS_RETRIEVED, params);
     }
 
     private void sendErrorEventToJs(RNSmsUserConsentException e) {
         WritableMap params = Arguments.createMap();
         params.putString(e.code, e.getMessage());
         reactContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit(AKV_SMS_RETRIEVE_ERROR, params);
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                .emit(AKV_SMS_RETRIEVE_ERROR, params);
+    }
+
+    @ReactMethod
+    public void addListener(String eventName) {
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
     }
 
     @ReactMethod


### PR DESCRIPTION
Remove maven to support newer react-native versions.

Tested to work with both older and newer versions of React Native: v0.63 and v0.68